### PR TITLE
Py37+

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   run:
     - python >=3.6
     - pyyaml >=3.13
-    - contextvars >=2.4
+    - contextvars >=2.4 # [py==36]
     - docstring_parser >=0.7.3
     - dataclasses >=0.8
     - jsonschema >=3.2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 
 build:
   number: 1
-  noarch: python
   script: {{ PYTHON }} -m pip install .[all] -vv
 
 requirements:
@@ -22,7 +21,7 @@ requirements:
   run:
     - python >=3.6
     - pyyaml >=3.13
-    - contextvars >=2.4 # [py==36]
+    - contextvars >=2.4  # [py==36]
     - docstring_parser >=0.7.3
     - dataclasses >=0.8
     - jsonschema >=3.2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,16 +12,16 @@ source:
 
 build:
   number: 1
+  noarch: python
   script: {{ PYTHON }} -m pip install .[all] -vv
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python >=3.7
   run:
-    - python >=3.6
+    - python >=3.7
     - pyyaml >=3.13
-    - contextvars >=2.4  # [py==36]
     - docstring_parser >=0.7.3
     - dataclasses >=0.8
     - jsonschema >=3.2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: d85c97d4a35070693dcd625648c81e6d2cbf81a1d9fbc071be7e3e90598c5fb4
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install .[all] -vv
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Closes #38 
<!--
Please add any other relevant info below:
-->

The external contextvars library is only aimed to backport python>=3.7 functionalities onto python=3.6. 

This drops the library dependency and bumps to python>=3.7, in which case the standard library should suffice.

I tried to keep the python=3.6 build using selectors but I cannot make it work